### PR TITLE
feat: Adding "pathBuilder" option to the input configuration

### DIFF
--- a/src/files.ts
+++ b/src/files.ts
@@ -88,13 +88,13 @@ export function getFileMethods(
         async download(path?: string) {
             const url = this.getUrl();
             path ??= await createTempFile();
-            if (!skipAbsolutePathCheck && isAbsolutePath(url)) await copyFile(url, path);
+            if (isAbsolutePath(url)) await copyFile(url, path);
             else await downloadFile(url, path);
             return path;
         },
         async *[Symbol.asyncIterator]() {
             const url = this.getUrl();
-            if (!skipAbsolutePathCheck && isAbsolutePath(url)) {
+            if (isAbsolutePath(url)) {
                 yield* readFile(url);
             } else {
                 yield* await fetchFile(url);

--- a/src/files.ts
+++ b/src/files.ts
@@ -73,7 +73,7 @@ export interface FileX {
 
 export function getFileMethods(
     linkBuilder: (path: string) => string | URL,
-    skipAbsolutePathCheck: boolean,
+    pathBuilder: (path: string) => string | URL | undefined,
 ) {
     const methods: FileX = {
         getUrl(this: File) {
@@ -82,8 +82,11 @@ export function getFileMethods(
                 const id = this.file_id;
                 throw new Error(`File path is not available for file '${id}'`);
             }
-            if (!skipAbsolutePathCheck && isAbsolutePath(path)) return path;
-            const link = linkBuilder(path);
+            if (isAbsolutePath(path)) {
+                var bpath = pathBuilder(path);
+                if (bpath === undefined) return path;
+            }
+            const link = bpath ?? linkBuilder(path);
             if (link instanceof URL) return link.href;
             return link;
         },

--- a/src/files.ts
+++ b/src/files.ts
@@ -33,7 +33,9 @@ export interface FileX {
      * you access to the downloaded file.
      *
      * If you are using a local Bot API server, then the local file will be
-     * copied over to the specified path, or to a new temporary location.
+     * copied over to the specified path, or to a new temporary location, unless
+     * you set `skipAbsolutePathCheck` to `true` in the main configuration, and
+     * set a custom `buildFileUrl` function that returns an URL.
      *
      * If the `file_path` of this file object is `undefined`, this method will
      * throw an error.

--- a/src/files.ts
+++ b/src/files.ts
@@ -34,8 +34,7 @@ export interface FileX {
      *
      * If you are using a local Bot API server, then the local file will be
      * copied over to the specified path, or to a new temporary location, unless
-     * you set `skipAbsolutePathCheck` to `true` in the main configuration, and
-     * set a custom `buildFileUrl` function that returns an URL.
+     * you set `buildFilePath`, which will be used instead of `buildFileUrl`.
      *
      * If the `file_path` of this file object is `undefined`, this method will
      * throw an error.
@@ -73,7 +72,7 @@ export interface FileX {
 
 export function getFileMethods(
     linkBuilder: (path: string) => string | URL,
-    pathBuilder: (path: string) => string | URL | undefined,
+    pathBuilder: (path: string) => string,
 ) {
     const methods: FileX = {
         getUrl(this: File) {
@@ -82,11 +81,8 @@ export function getFileMethods(
                 const id = this.file_id;
                 throw new Error(`File path is not available for file '${id}'`);
             }
-            if (isAbsolutePath(path)) {
-                var bpath = pathBuilder(path);
-                if (bpath === undefined) return path;
-            }
-            const link = bpath ?? linkBuilder(path);
+            if (isAbsolutePath(path)) return pathBuilder(path);
+            const link = linkBuilder(path);
             if (link instanceof URL) return link.href;
             return link;
         },

--- a/src/files.ts
+++ b/src/files.ts
@@ -71,6 +71,7 @@ export interface FileX {
 
 export function getFileMethods(
     linkBuilder: (path: string) => string | URL,
+    skipAbsolutePathCheck: boolean,
 ) {
     const methods: FileX = {
         getUrl(this: File) {
@@ -79,7 +80,7 @@ export function getFileMethods(
                 const id = this.file_id;
                 throw new Error(`File path is not available for file '${id}'`);
             }
-            if (isAbsolutePath(path)) return path;
+            if (!skipAbsolutePathCheck && isAbsolutePath(path)) return path;
             const link = linkBuilder(path);
             if (link instanceof URL) return link.href;
             return link;
@@ -87,13 +88,13 @@ export function getFileMethods(
         async download(path?: string) {
             const url = this.getUrl();
             path ??= await createTempFile();
-            if (isAbsolutePath(url)) await copyFile(url, path);
+            if (!skipAbsolutePathCheck && isAbsolutePath(url)) await copyFile(url, path);
             else await downloadFile(url, path);
             return path;
         },
         async *[Symbol.asyncIterator]() {
             const url = this.getUrl();
-            if (isAbsolutePath(url)) {
+            if (!skipAbsolutePathCheck && isAbsolutePath(url)) {
                 yield* readFile(url);
             } else {
                 yield* await fetchFile(url);

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -84,7 +84,7 @@ export interface FilesPluginOptions {
         token: string,
         path: string,
         env: "prod" | "test",
-    ) => string | URL;
+    ) => string;
 }
 
 /**
@@ -120,7 +120,7 @@ export function hydrateFiles<R extends RawApi = RawApi>(
     const buildPath = (path: string) =>
         buildFilePath
             ? buildFilePath(root, token, path, environment)
-            : undefined;
+            : path;
 
     const methods = getFileMethods(buildLink, buildPath);
     const t: Transformer = async (prev, method, payload, signal) => {

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -66,9 +66,9 @@ export interface FilesPluginOptions {
     ) => string | URL;
     /**
      * If set to `true`, the plugin will not check whether the file path
-     * is an absolute path. This is useful if you are using a local Bot API Server
-     * but the server is on another machine, and you want to download files
-     * from a custom location.
+     * is an absolute path when getting the file URL. This is useful 
+     * if you are using a local Bot API Server, but the server is on 
+     * another machine, and you want to download files from a custom location.
      */
     skipAbsolutePathCheck?: boolean;
 }

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -64,6 +64,13 @@ export interface FilesPluginOptions {
         path: string,
         env: "prod" | "test",
     ) => string | URL;
+    /**
+     * If set to `true`, the plugin will not check whether the file path
+     * is an absolute path. This is useful if you are using a local Bot API Server
+     * but the server is on another machine, and you want to download files
+     * from a custom location.
+     */
+    skipAbsolutePathCheck?: boolean;
 }
 
 /**
@@ -90,10 +97,11 @@ export function hydrateFiles<R extends RawApi = RawApi>(
 ): Transformer<R> {
     const root = options?.apiRoot ?? "https://api.telegram.org";
     const environment = options?.environment ?? "prod";
+    const skipAbsolutePathCheck = options?.skipAbsolutePathCheck ?? false;
     const buildFileUrl = options?.buildFileUrl ?? defaultBuildFileUrl;
     const buildLink = (path: string) =>
         buildFileUrl(root, token, path, environment);
-    const methods = getFileMethods(buildLink);
+    const methods = getFileMethods(buildLink, skipAbsolutePathCheck);
     const t: Transformer = async (prev, method, payload, signal) => {
         const res = await prev(method, payload, signal);
         if (res.ok && isFile(res.result)) {


### PR DESCRIPTION
### Please check my code before, I have no idea how to test this.
It would be useful to add an option to skip "isAbsolutePath" for custom local Bot Api Servers endpoints.

As for example, my local api server returns "/var/lib/telegram-bot-api/..." when getting a file object, but as it's on a docker container, it is impossible to access it via normal manners (like copying the file to a temporal location as this plugin does), so I have configured a nginx server pointing to a different subdomain, where I can access that folder, so it's much easier and safe. 
Setting this option, and also setting a custom "buildFileUrl" will make the plugin work with my custom configuration. 